### PR TITLE
added deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Google-Calendar-Guests-Can-Modify-Event-By-Default
 
+_**PLEASE NOTE:** This extension is now obsolete, as the new calendar now supports setting this as default. Simply edit "Default Guest Permissions" in Google Calendar Settings. :)_
+
+![How to enable](https://user-images.githubusercontent.com/474248/31768140-4ad2bb1a-b4ce-11e7-823b-d7b7c1885b50.png)
+
+---
+
 Chrome extension that enables 'Guests can modify event' setting for google calendar by default, when creating a new event.
 
 You can install it from [the Chrome Webstore](https://chrome.google.com/webstore/detail/google-calendar-guests-mo/hjhicmeghjagaicbkmhmbbnibhbkcfdb).


### PR DESCRIPTION
Added a deprecation notice per @robin-drexler's [comment](https://github.com/robin-drexler/Google-Calendar-Guests-Can-Modify-Event-By-Default/issues/1#issuecomment-337875155) on #1.

This adds a note to the README stating the extension is now obsolete.